### PR TITLE
Improve service contracts, make 'em less strict

### DIFF
--- a/sample/src/main/java/io/techery/janet/proxy/sample/ProxySample.java
+++ b/sample/src/main/java/io/techery/janet/proxy/sample/ProxySample.java
@@ -9,6 +9,7 @@ import io.techery.janet.gson.GsonConverter;
 import io.techery.janet.http.annotations.HttpAction;
 import io.techery.janet.okhttp.OkClient;
 import io.techery.janet.proxy.sample.actions.GithubAction;
+import io.techery.janet.proxy.sample.actions.base.LabeledAction;
 import io.techery.janet.proxy.sample.actions.XkcdAction;
 import rx.Observable;
 import rx.schedulers.Schedulers;
@@ -23,19 +24,17 @@ public class ProxySample {
         .addService(new SampleLoggingService(new ProxyService.Builder(HttpAction.class)
             .add(
                 new HttpActionService("https://api.github.com", client, converter),
-                action -> action.getLabel().equals("github"))
+                action -> ((LabeledAction) action).label().equals("github"))
             .add(
                 new HttpActionService("http://xkcd.com", client, converter),
-                action -> action.getLabel().equals("xkcd"))
+                action -> ((LabeledAction) action).label().equals("xkcd"))
             .build()
         )).build();
 
     Observable.combineLatest(
         janet.createPipe(GithubAction.class, Schedulers.io()).createObservableResult(new GithubAction()),
         janet.createPipe(XkcdAction.class, Schedulers.io()).createObservableResult(new XkcdAction()),
-        (githubAction, xkcdAction) -> {
-          return null;
-        }
+        (githubAction, xkcdAction) -> null
     ).toBlocking().subscribe();
   }
 }

--- a/sample/src/main/java/io/techery/janet/proxy/sample/actions/GithubAction.java
+++ b/sample/src/main/java/io/techery/janet/proxy/sample/actions/GithubAction.java
@@ -4,12 +4,12 @@ import java.util.ArrayList;
 
 import io.techery.janet.http.annotations.HttpAction;
 import io.techery.janet.http.annotations.Response;
-import io.techery.janet.proxy.LabeledAction;
+import io.techery.janet.proxy.sample.actions.base.LabeledAction;
 
 @HttpAction("/users/techery/repos")
 public class GithubAction implements LabeledAction {
 
-  @Override public String getLabel() {
+  @Override public String label() {
     return "github";
   }
 

--- a/sample/src/main/java/io/techery/janet/proxy/sample/actions/XkcdAction.java
+++ b/sample/src/main/java/io/techery/janet/proxy/sample/actions/XkcdAction.java
@@ -2,12 +2,12 @@ package io.techery.janet.proxy.sample.actions;
 
 import io.techery.janet.http.annotations.HttpAction;
 import io.techery.janet.http.annotations.Response;
-import io.techery.janet.proxy.LabeledAction;
+import io.techery.janet.proxy.sample.actions.base.LabeledAction;
 
 @HttpAction("/info.0.json")
 public class XkcdAction implements LabeledAction {
 
-  @Override public String getLabel() {
+  @Override public String label() {
     return "xkcd";
   }
 

--- a/sample/src/main/java/io/techery/janet/proxy/sample/actions/base/LabeledAction.java
+++ b/sample/src/main/java/io/techery/janet/proxy/sample/actions/base/LabeledAction.java
@@ -1,0 +1,5 @@
+package io.techery.janet.proxy.sample.actions.base;
+
+public interface LabeledAction {
+  String label();
+}

--- a/service/src/main/java/io/techery/janet/proxy/LabeledAction.java
+++ b/service/src/main/java/io/techery/janet/proxy/LabeledAction.java
@@ -1,5 +1,0 @@
-package io.techery.janet.proxy;
-
-public interface LabeledAction {
-  String getLabel();
-}

--- a/service/src/main/java/io/techery/janet/proxy/ServiceMappingRule.java
+++ b/service/src/main/java/io/techery/janet/proxy/ServiceMappingRule.java
@@ -1,5 +1,5 @@
 package io.techery.janet.proxy;
 
-public interface ServiceMappingRule {
-  boolean matches(LabeledAction action);
+public interface ServiceMappingRule<T> {
+  boolean matches(T action);
 }

--- a/service/src/test/java/io/techery/janet/ProxyTest.java
+++ b/service/src/test/java/io/techery/janet/ProxyTest.java
@@ -6,12 +6,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import io.techery.janet.model.LabeledAction;
 import io.techery.janet.model.MockServiceAction;
 import io.techery.janet.model.MockTestAction1;
 import io.techery.janet.model.MockTestAction2;
 import io.techery.janet.model.MockTestAction3;
 import io.techery.janet.model.OtherServiceAction;
-import io.techery.janet.proxy.LabeledAction;
 import io.techery.janet.proxy.ServiceMappingRule;
 import rx.observers.TestSubscriber;
 
@@ -35,14 +35,14 @@ public class ProxyTest {
     service2 = provideService();
     janet = new Janet.Builder()
         .addService(new ProxyService.Builder(MockServiceAction.class)
-            .add(service1, new ServiceMappingRule() {
+            .add(service1, new ServiceMappingRule<LabeledAction>() {
               @Override public boolean matches(LabeledAction action) {
-                return action.getLabel().equals("service1");
+                return action.label().equals("service1");
               }
             })
-            .add(service2, new ServiceMappingRule() {
+            .add(service2, new ServiceMappingRule<LabeledAction>() {
               @Override public boolean matches(LabeledAction action) {
-                return action.getLabel().equals("service2");
+                return action.label().equals("service2");
               }
             })
             .build()
@@ -114,7 +114,7 @@ public class ProxyTest {
         when(service.getSupportedAnnotationType()).thenReturn(OtherServiceAction.class);
         new ProxyService.Builder(MockServiceAction.class)
             .add(service, new ServiceMappingRule() {
-              @Override public boolean matches(LabeledAction action) {
+              @Override public boolean matches(Object action) {
                 return true;
               }
             })

--- a/service/src/test/java/io/techery/janet/model/LabeledAction.java
+++ b/service/src/test/java/io/techery/janet/model/LabeledAction.java
@@ -1,0 +1,5 @@
+package io.techery.janet.model;
+
+public interface LabeledAction {
+  String label();
+}

--- a/service/src/test/java/io/techery/janet/model/MockTestAction1.java
+++ b/service/src/test/java/io/techery/janet/model/MockTestAction1.java
@@ -1,10 +1,8 @@
 package io.techery.janet.model;
 
-import io.techery.janet.proxy.LabeledAction;
-
 @MockServiceAction
 public class MockTestAction1 implements LabeledAction {
-  @Override public String getLabel() {
+  @Override public String label() {
     return "service1";
   }
 }

--- a/service/src/test/java/io/techery/janet/model/MockTestAction2.java
+++ b/service/src/test/java/io/techery/janet/model/MockTestAction2.java
@@ -1,10 +1,8 @@
 package io.techery.janet.model;
 
-import io.techery.janet.proxy.LabeledAction;
-
 @MockServiceAction
 public class MockTestAction2 implements LabeledAction {
-  @Override public String getLabel() {
+  @Override public String label() {
     return "service2";
   }
 }

--- a/service/src/test/java/io/techery/janet/model/MockTestAction3.java
+++ b/service/src/test/java/io/techery/janet/model/MockTestAction3.java
@@ -1,10 +1,8 @@
 package io.techery.janet.model;
 
-import io.techery.janet.proxy.LabeledAction;
-
 @MockServiceAction
 public class MockTestAction3 implements LabeledAction {
-  @Override public String getLabel() {
+  @Override public String label() {
     return "service3";
   }
 }

--- a/service/src/test/java/io/techery/janet/model/OtherTestAction.java
+++ b/service/src/test/java/io/techery/janet/model/OtherTestAction.java
@@ -1,10 +1,8 @@
 package io.techery.janet.model;
 
-import io.techery.janet.proxy.LabeledAction;
-
 @OtherServiceAction
 public class OtherTestAction implements LabeledAction {
-  @Override public String getLabel() {
-    return "service1";
+  @Override public String label() {
+    return "some_service";
   }
 }


### PR DESCRIPTION
## Scope
1. Currently, `ServiceMatchingRule`, which is the contract to find proper child service to process the action, is strictly bounded to `LabeledAction`, so makes it less flexible and redundant.
2. Service are checked in random order which makes no way to set rules some priority.

## Solution
* Remove `LabeledAction` from rule contract;
* Store service&rule as `LinkedList` and process 'em in order of being added